### PR TITLE
Add support for `:merge-opts` in REPL `-setup` return value

### DIFF
--- a/src/cemerick/piggieback.clj
+++ b/src/cemerick/piggieback.clj
@@ -180,8 +180,8 @@
                     (dissoc :repl-env :eval))
         eval (or eval
                  (when (rhino-repl-env? repl-env)
-                   #(with-rhino-context (apply cljs-eval options %&)))
-                 #(apply cljs-eval options %&))]
+                   #(with-rhino-context (apply cljs-eval *cljs-repl-options* %&)))
+                 #(apply cljs-eval *cljs-repl-options* %&))]
 
     (set! *cljs-repl-options* options)
     (set! *eval* eval)
@@ -198,9 +198,10 @@
       (try
         (env/with-compiler-env compiler-env
           (set! *cljs-repl-env* repl-env)
-          ((if (rhino-repl-env? repl-env) setup-rhino-env cljsrepl/-setup)
-           repl-env
-           options))
+          (when-let [merge-opts (:merge-opts ((if (rhino-repl-env? repl-env) setup-rhino-env cljsrepl/-setup)
+                                               repl-env
+                                               options))]
+            (set! *cljs-repl-options* (merge *cljs-repl-options* merge-opts))))
         (catch Exception e
           (reset-repl-state)
           (throw e))))


### PR DESCRIPTION
The ClojureScript `cljs.repl` implementation has been updated to allow
REPLs to further configure compilation as a result of executing
`-setup`. This is done by looking up a special `:merge-opts` key in
the return value of `-setup`, and merging those options back into the
original options.

This patch accomplishes the same for Piggieback by mirroring that
behavior, merging results back into `*cljs-repl-options*`, and by
modifying `eval` to consult that dynamic var.

This would address issue #43