### PR TITLE
Print a better error when failing to load middleware

### DIFF
--- a/src/cemerick/piggieback.clj
+++ b/src/cemerick/piggieback.clj
@@ -217,7 +217,11 @@
   ; environment after each eval
   (try
     (let [repl-env (delegating-repl-env repl-env nil)]
-      (set! ana/*cljs-ns* 'cljs.user)
+      (try
+        (set! ana/*cljs-ns* 'cljs.user)
+        (catch IllegalStateException e
+          (println "Can't set root bindings. This is likely caused by the nrepl middleware failing to load. You may have misconfigured it, or it could be a result of running in an unsupported environment (specifically `lein trampoline repl` generally doesn't work right; run without trampoline). Exact exception below.")
+          (throw e)))
       ; this will implicitly set! *cljs-compiler-env*
       (run-cljs-repl (assoc ieval/*msg* ::first-cljs-repl true)
         (nrepl/code (ns cljs.user
@@ -232,7 +236,10 @@
       (set! *ns* (find-ns ana/*cljs-ns*))
       (println "To quit, type:" :cljs/quit))
     (catch Exception e
-      (set! *cljs-repl-env* nil)
+      (try
+        (set! *cljs-repl-env* nil)
+        ;;bury so we get the real exception
+        (catch Exception _))
       (throw e))))
 
 ;; mostly a copy/paste from interruptible-eval


### PR DESCRIPTION
Finally getting around to addressing #34. Demo:

```
-> lein trampoline repl
REPL-y 0.3.5, nREPL 0.2.10
Clojure 1.6.0
Java HotSpot(TM) 64-Bit Server VM 1.8.0_45-b14
    Docs: (doc function-name-here)
          (find-doc "part-of-name-here")
  Source: (source function-name-here)
 Javadoc: (javadoc java-object-or-class-here)
    Exit: Control+D or (exit) or (quit)
 Results: Stored in vars *1, *2, *3, an exception in *e

zs.client.browser-repl=> (piggieback/cljs-repl (weasel/repl-env :ip "0.0.0.0" :port 9003))
Can't set root bindings. This is likely caused by the nrepl middleware failing to load. You may have misconfigured it, or it could be a result of running in an unsupported environment (specifically `lein trampoline repl` generally doesn't work right; run without trampoline). Exact exception below.

IllegalStateException Can't change/establish root binding of: *cljs-ns* with set  clojure.lang.Var.set (Var.java:221)
```
