### PR TITLE
Update the current session's #'*e on uncaught exceptions.

### DIFF
--- a/src/cemerick/piggieback.clj
+++ b/src/cemerick/piggieback.clj
@@ -199,6 +199,7 @@
            :caught (fn [err repl-env repl-options]
                      (let [root-ex (#'clojure.main/root-cause err)]
                        (when-not (instance? ThreadDeath root-ex)
+                         (swap! session assoc #'*e err)
                          (transport/send transport (response-for nrepl-msg {:status :eval-error
                                                                             :ex (-> err class str)
                                                                             :root-ex (-> root-ex class str)}))


### PR DESCRIPTION
This is needed for things like cider.nrepl.middleware.stacktrace which tries to
retrieve the last exception and extract its stacktrace.

Together with https://github.com/alessandrod/cider-nrepl/commit/a528fa3f13b3c0eff723f8ed17c015fe7efb4e84 this allows stacktraces to be retrieved for clojurescript exceptions. 